### PR TITLE
Add 90s theme

### DIFF
--- a/app/nineties.css
+++ b/app/nineties.css
@@ -1,0 +1,32 @@
+@layer base {
+  .theme-90s {
+    font-family: 'Comic Neue', 'Comic Sans MS', cursive, sans-serif;
+    background-image: linear-gradient(45deg, #00ffff, #ff00ff);
+    color: #000;
+  }
+
+  .theme-90s header,
+  .theme-90s footer {
+    background-color: #ffff33;
+    color: #000;
+    text-align: center;
+    padding: 1rem;
+    font-family: 'Press Start 2P', cursive;
+  }
+
+  .theme-90s nav ul {
+    @apply flex gap-4 list-none justify-center;
+  }
+
+  .theme-90s nav a {
+    color: #000;
+    text-decoration: none;
+    font-weight: bold;
+  }
+
+  .theme-90s nav a:hover {
+    color: #ff6600;
+    text-decoration: underline;
+  }
+}
+

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,6 +9,7 @@ import {
 
 import type { Route } from "./+types/root";
 import "./app.css";
+import "./nineties.css";
 import Header from "./components/Header"; // Import Header
 import Footer from "./components/Footer"; // Import Footer
 export const links: Route.LinksFunction = () => [
@@ -22,6 +23,10 @@ export const links: Route.LinksFunction = () => [
     rel: "stylesheet",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
+  {
+    rel: "stylesheet",
+    href: "https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&family=Press+Start+2P&display=swap",
+  },
 ];
 
 export function Layout({ children }: { children: React.ReactNode }) {
@@ -33,7 +38,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body>
+      <body className="theme-90s">
         {children}
         <ScrollRestoration />
         <Scripts />


### PR DESCRIPTION
## Summary
- add 90s fonts and styles
- import new styles in the app and apply `theme-90s` class

## Testing
- `npm run typecheck` *(fails: react-router not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500b7f65788324bd108c2a0652dd15